### PR TITLE
修复融合设备中心显示与通知栏开关异常

### DIFF
--- a/app/src/main/java/moe/chenxy/huaweipods/hook/BluetoothUpstreamHeadsetHook.kt
+++ b/app/src/main/java/moe/chenxy/huaweipods/hook/BluetoothUpstreamHeadsetHook.kt
@@ -34,6 +34,7 @@ import moe.chenxy.huaweipods.utils.miuiStrongToast.data.HuaweiPodsAction
 import moe.chenxy.huaweipods.utils.miuiStrongToast.data.addHuaweiPodsAction
 import moe.chenxy.huaweipods.utils.miuiStrongToast.data.PodParams
 import moe.chenxy.huaweipods.utils.miuiStrongToast.data.normalizedEarbudAvailability
+import moe.chenxy.huaweipods.utils.SystemApisUtils.cancelAsUser
 import org.json.JSONObject
 
 @SuppressLint("MissingPermission")
@@ -77,6 +78,7 @@ class BluetoothUpstreamHeadsetHook : HookContext() {
 
     override fun onHook() {
         hookHeadsetServiceBinder()
+        hookMiuiHeadsetBinder()
         hookNotificationBatteryUpstream()
         hookHuaweiHfpBattery()
     }
@@ -497,11 +499,29 @@ class BluetoothUpstreamHeadsetHook : HookContext() {
         hookAddressBooleanResult(binderClass, listOf("getRingFindState", "mo19772m0", "m0"), "getRingFindState", false)
 
         runCatching {
-            hookBefore(binderClass.method("setCommonCommand", Int::class.java, String::class.java, BluetoothDevice::class.java)) {
+            val method = binderClass.declaredMethods.firstOrNull { candidate ->
+                candidate.returnType == String::class.java &&
+                    candidate.parameterTypes.contentEquals(
+                        arrayOf(
+                            Int::class.javaPrimitiveType!!,
+                            String::class.java,
+                            BluetoothDevice::class.java,
+                        ),
+                    )
+            } ?: return@runCatching
+            method.isAccessible = true
+            hookBefore(method) {
                 val command = args[0] as? Int
                 val value = args[1] as? String
                 val device = args[2] as? BluetoothDevice
                 if (!isHuaweiPod(device)) return@hookBefore
+                // 114/115 是通知栏开关；114 的值“1”表示断开设备，继续交给原实现。
+                if (command == COMMAND_SET_DETAIL_NOTIFICATION ||
+                    command == COMMAND_GET_DETAIL_NOTIFICATION
+                ) {
+                    detailNotificationResponse(command, value, device)?.let { result = it }
+                    return@hookBefore
+                }
                 lastHuaweiDevice = device
                 result = when (command) {
                     102 -> "1"
@@ -707,6 +727,7 @@ class BluetoothUpstreamHeadsetHook : HookContext() {
         runCatching {
             hookBefore(findMethod(stubClass, "onTransact", Int::class.java, Parcel::class.java, Parcel::class.java, Int::class.java)) {
                 val code = args[0] as? Int ?: return@hookBefore
+                if (code != TRANSACTION_SET_COMMON_COMMAND) return@hookBefore
                 val data = args[1] as? Parcel ?: return@hookBefore
                 val reply = args[2] as? Parcel ?: return@hookBefore
                 handleTransaction(code, data, reply)?.let { handled ->
@@ -881,6 +902,16 @@ class BluetoothUpstreamHeadsetHook : HookContext() {
         Log.d(TAG, "setCommonCommand upstream command=$command value=$value device=${device.describe()} isHuawei=$isHuawei")
         if (!isHuawei) return null
         lastHuaweiDevice = device
+        detailNotificationResponse(command, value, device)?.let { response ->
+            reply.writeNoException()
+            reply.writeString(response)
+            return true
+        }
+        if (command == COMMAND_SET_DETAIL_NOTIFICATION ||
+            command == COMMAND_GET_DETAIL_NOTIFICATION
+        ) {
+            return null
+        }
         reply.writeNoException()
         reply.writeString(
             when (command) {
@@ -891,6 +922,50 @@ class BluetoothUpstreamHeadsetHook : HookContext() {
         )
         sendRealStatus(device, "setCommonCommand:$command")
         return true
+    }
+
+    private fun detailNotificationResponse(
+        command: Int?,
+        value: String?,
+        device: BluetoothDevice?,
+    ): String? {
+        if (packageName != "com.xiaomi.bluetooth" || command == null || device == null) return null
+        val ctx = context ?: return null
+        val address = runCatching { device.address }.getOrNull()?.takeIf(String::isNotBlank)
+            ?: return null
+        val preferences = ctx.getSharedPreferences("DeviceIdCached", Context.MODE_MULTI_PROCESS)
+        val key = "detail_notification$address"
+        if (command == COMMAND_SET_DETAIL_NOTIFICATION) {
+            val enabled = when (value) {
+                "true" -> true
+                "false" -> false
+                else -> return null
+            }
+            if (!preferences.edit().putBoolean(key, enabled).commit()) return null
+            if (enabled) {
+                ctx.sendBroadcast(Intent(HuaweiPodsAction.ACTION_REFRESH_STATUS).apply {
+                    putExtra(HuaweiPodsAction.EXTRA_RESTORE_NOTIFICATION, true)
+                    setPackage("com.android.bluetooth")
+                    addFlags(Intent.FLAG_RECEIVER_FOREGROUND)
+                })
+            } else {
+                cancelDetailNotification(ctx, address)
+            }
+            return ""
+        }
+        if (command == COMMAND_GET_DETAIL_NOTIFICATION) {
+            return preferences.getBoolean(key, false).toString()
+        }
+        return null
+    }
+
+    private fun cancelDetailNotification(ctx: Context, address: String) {
+        (ctx.getSystemService(Context.NOTIFICATION_SERVICE) as? android.app.NotificationManager)
+            ?.cancelAsUser(
+                "BTHeadset$address",
+                DETAIL_NOTIFICATION_ID,
+                moe.chenxy.huaweipods.utils.SystemApisUtils.getUserAllUserHandle(),
+            )
     }
 
     private fun handleCommonConfig(data: Parcel, reply: Parcel): Boolean? {
@@ -1306,6 +1381,10 @@ class BluetoothUpstreamHeadsetHook : HookContext() {
     }
 
     private companion object {
+        private const val TRANSACTION_SET_COMMON_COMMAND = 14
+        private const val COMMAND_SET_DETAIL_NOTIFICATION = 114
+        private const val COMMAND_GET_DETAIL_NOTIFICATION = 115
+        private const val DETAIL_NOTIFICATION_ID = 10003
         private const val FREEBUDS3_BATTERY_RESPONSE = "+HUAWEIBATTERY=OK"
         private const val AT_RESPONSE_OK = 1
     }

--- a/app/src/main/java/moe/chenxy/huaweipods/hook/MiBluetoothToastHook.kt
+++ b/app/src/main/java/moe/chenxy/huaweipods/hook/MiBluetoothToastHook.kt
@@ -68,6 +68,19 @@ object MiBluetoothToastHook : HookContext() {
             }
             try {
                 val address: String = bluetoothDevice.address
+                val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                fun detailNotificationEnabled(): Boolean = context.getSharedPreferences(
+                    "DeviceIdCached",
+                    Context.MODE_MULTI_PROCESS,
+                ).getBoolean("detail_notification$address", false)
+                if (!detailNotificationEnabled()) {
+                    notificationManager.cancelAsUser(
+                        "BTHeadset$address",
+                        10003,
+                        SystemApisUtils.getUserAllUserHandle(),
+                    )
+                    return
+                }
                 var alias: String? = bluetoothDevice.alias
                 if (alias?.isEmpty() == true) {
                     alias = bluetoothDevice.name
@@ -114,7 +127,6 @@ object MiBluetoothToastHook : HookContext() {
                 else ""
 
                 val contentText: String = caseBattStr + leftEar + rightEar
-                val notificationManager = context.getSystemService("notification") as NotificationManager
                 notificationManager.createNotificationChannel(
                     NotificationChannel(
                         "BTHeadset$address",
@@ -277,6 +289,13 @@ object MiBluetoothToastHook : HookContext() {
                     notification,
                     SystemApisUtils.getUserAllUserHandle()
                 )
+                if (!detailNotificationEnabled()) {
+                    notificationManager.cancelAsUser(
+                        "BTHeadset$address",
+                        10003,
+                        SystemApisUtils.getUserAllUserHandle(),
+                    )
+                }
             } catch (e: Exception) {
                 Log.e("HuaweiPods", "Failed to create Pod Notification", e)
             }

--- a/app/src/main/java/moe/chenxy/huaweipods/hook/SettingsHeadsetHook.kt
+++ b/app/src/main/java/moe/chenxy/huaweipods/hook/SettingsHeadsetHook.kt
@@ -317,6 +317,10 @@ object SettingsHeadsetHook : HookContext() {
                 if (methodName == "setCommonCommand") proxySetCommonCommandCalls++
                 Log.d(TAG, "$methodName proxy call#${if (methodName == "setCommonCommand") proxySetCommonCommandCalls else -1} args=${args.describeArgs()} device=${device.describe()} addressArg=$address isHuawei=$isHuawei")
                 if (!isHuawei) return@hookBefore
+                // 通知栏开关交给蓝牙服务处理。
+                if (methodName == "setCommonCommand" && (args[0] == 114 || args[0] == 115)) {
+                    return@hookBefore
+                }
                 this.result = result(args)
                 Log.d(TAG, "$methodName proxy forced result=${this.result} address=${device?.address ?: address}")
             }

--- a/app/src/main/java/moe/chenxy/huaweipods/hook/milink/MiLinkServiceHook.kt
+++ b/app/src/main/java/moe/chenxy/huaweipods/hook/milink/MiLinkServiceHook.kt
@@ -156,12 +156,16 @@ internal fun miLinkAncModeFor(
 
 /**
  * 小米的虚拟耳机模板始终读取一个 ANC 状态，即使当前机型没有 ANC。
- * 无 ANC 机型只向宿主返回“关闭”，写操作仍由能力检查拒绝。
+ * 无 ANC 机型必须返回“不可用”，否则宿主仍会按“支持但已关闭”保留区块高度。
  */
 internal fun miLinkHostAncStateFor(
     route: HuaweiDeviceRoute,
     huaweiStatus: Int,
-): Int = miLinkAncModeFor(route, huaweiStatus) ?: 0
+): Int = miLinkAncModeFor(route, huaweiStatus) ?: -1
+
+/** ANC 开关能力与音频切换能力相互独立。 */
+internal fun miLinkAncSwitchStateFor(route: HuaweiDeviceRoute): Int =
+    if (route.supportsAnc) 1 else 0
 
 /**
  * 融合设备中心使用 0=关闭、1=头部跟踪、2=固定；这与耳机 AAM 的
@@ -279,6 +283,7 @@ object MiLinkServiceHook : HookContext() {
     private const val PREF_TRANSPARENCY_SUBMODE = "transparency_submode"
     private const val PREF_DEVICE_ROUTE = "device_route"
     private const val FREECLIP2_AUDIO_REFRESH_MIN_INTERVAL_MS = 750L
+    private const val DEVICE_SESSION_REQUEST_MIN_INTERVAL_MS = 1_500L
     private val bluetoothAddressPattern = Regex("^(?:[0-9A-F]{2}:){5}[0-9A-F]{2}$")
     private val ancIdentityGetterNames = listOf(
         "getAddress",
@@ -338,6 +343,7 @@ object MiLinkServiceHook : HookContext() {
     private var currentFreeClip2SoundEffect = FreeClip2SoundEffect.DEFAULT
     private val freeClip2AudioPendingGate = FreeClip2AudioPendingGate()
     private var lastFreeClip2AudioRefreshRequestAt = 0L
+    private var lastDeviceSessionRequestAt = 0L
     private val freeClip2AudioInternalRenderDepth = AtomicInteger(0)
     private var currentSessionConfirmed = false
     internal var lastAncBatteryController: Any? = null
@@ -354,6 +360,7 @@ object MiLinkServiceHook : HookContext() {
         hookContextEntry()
         hookMxBluetoothRuntime()
         hookHeadsetRuntimeDisplay()
+        hookSupportedAncModes()
         hookHeadsetCirculationExperiment()
         hookWindowsHeadsetCirculationCapability()
         hookWindowsHeadsetBondState()
@@ -388,6 +395,7 @@ object MiLinkServiceHook : HookContext() {
                 className,
                 "getAncState",
                 requiresCurrentState = true,
+                noAncResult = { -1 },
             ) { miLinkAncState() }
             hookBluetoothDeviceResult(className, "getDeviceRunInfo") { 0 }
             hookBluetoothDeviceResult(className, "getWearStatus") { "0,0" }
@@ -416,6 +424,7 @@ object MiLinkServiceHook : HookContext() {
             "com.miui.headset.runtime.AncBatteryController",
             "getAncState",
             requiresCurrentState = true,
+            noAncResult = { -1 },
         ) { miLinkAncState() }
         hookBluetoothDeviceResult(
             "com.miui.headset.runtime.AncBatteryController",
@@ -427,7 +436,7 @@ object MiLinkServiceHook : HookContext() {
             "getHeadsetPropertyBlock",
             requiresCurrentState = true,
         ) { batteryPercentForMiLink() }
-        hookStringAddressResult("com.miui.headset.runtime.AncBatteryController", "getSwitchState") { miLinkSwitchState() }
+        hookAncSwitchStateResult("com.miui.headset.runtime.AncBatteryController")
         hookTransparentFeatureMethods("com.miui.headset.runtime.AncBatteryController")
         hookTransparentFeatureMethods("com.miui.headset.runtime.ProfileContext")
         hookTransparentFeatureMethods("com.miui.headset.api.HeadsetInfo")
@@ -436,10 +445,66 @@ object MiLinkServiceHook : HookContext() {
         hookHeadsetInfoNoArg("component3") { fakeDeviceId() }
         hookHeadsetInfoNoArg("getPowers", requiresCurrentState = true) { miLinkBatteryLevels() }
         hookHeadsetInfoNoArg("component4", requiresCurrentState = true) { miLinkBatteryLevels() }
-        hookHeadsetInfoNoArg("getMode", requiresCurrentState = true) { miLinkAncState() }
-        hookHeadsetInfoNoArg("component5", requiresCurrentState = true) { miLinkAncState() }
-        hookHeadsetInfoNoArg("getSwitchState", requiresCurrentState = true) { miLinkSwitchState() }
-        hookHeadsetInfoNoArg("component8", requiresCurrentState = true) { miLinkSwitchState() }
+        hookHeadsetInfoNoArg(
+            "getMode",
+            requiresCurrentState = true,
+            noAncResult = { -1 },
+        ) { miLinkAncState() }
+        hookHeadsetInfoNoArg(
+            "component5",
+            requiresCurrentState = true,
+            noAncResult = { -1 },
+        ) { miLinkAncState() }
+        hookHeadsetInfoNoArg(
+            "getSwitchState",
+            requiresCurrentState = true,
+            noAncResult = { 0 },
+        ) { miLinkSwitchState() }
+        hookHeadsetInfoNoArg(
+            "component8",
+            requiresCurrentState = true,
+            noAncResult = { 0 },
+        ) { miLinkSwitchState() }
+    }
+
+    private fun hookAncSwitchStateResult(className: String) {
+        runCatching {
+            hookAfter(findMethod(className, "getSwitchState", String::class.java)) {
+                val address = args[0] as? String ?: return@hookAfter
+                val route = routeForAddress(address)
+                if (!route.isSupported) return@hookAfter
+                result = miLinkAncSwitchStateFor(route)
+            }
+        }.onFailure { Log.w(TAG, "hook $className.getSwitchState(String) skipped", it) }
+    }
+
+    /** 融合设备中心在绑定详情页前读取 ANC 能力，并据此决定区块和弹窗高度。 */
+    private fun hookSupportedAncModes() {
+        listOf(
+            "com.miui.headset.runtime.QueryLocal",
+            "com.miui.headset.runtime.QueryServer",
+        ).forEach { className ->
+            runCatching {
+                hookBefore(
+                    findMethod(
+                        className,
+                        "getSupportAncMode",
+                        String::class.java,
+                        String::class.java,
+                    ),
+                ) {
+                    val address = (args.firstOrNull() as? String)
+                        ?.trim()
+                        ?.uppercase()
+                        ?.takeIf(bluetoothAddressPattern::matches)
+                        ?: return@hookBefore
+                    val route = routeForAddress(address)
+                    if (route.isSupported && !route.supportsAnc) {
+                        result = 0
+                    }
+                }
+            }.onFailure { Log.w(TAG, "hook $className.getSupportAncMode skipped", it) }
+        }
     }
 
     internal fun hookBluetoothDeviceResult(
@@ -447,6 +512,7 @@ object MiLinkServiceHook : HookContext() {
         methodName: String,
         requiresAnc: Boolean = false,
         requiresCurrentState: Boolean = false,
+        noAncResult: (() -> Any)? = null,
         result: () -> Any,
     ) {
         runCatching {
@@ -454,9 +520,14 @@ object MiLinkServiceHook : HookContext() {
                 val device = args[0] as? BluetoothDevice ?: return@hookAfter
                 val route = routeForDevice(device)
                 if (!route.isSupported || requiresAnc && !route.supportsAnc) return@hookAfter
+                if (!route.supportsAnc && noAncResult != null) {
+                    this.result = noAncResult()
+                    return@hookAfter
+                }
                 if (requiresCurrentState && !isCurrentHuaweiDevice(device, route)) return@hookAfter
                 cacheRuntimeOwner(className, instance)
                 captureRuntimeContext(instance)
+                if (requiresCurrentState && !currentSessionConfirmed) requestCurrentDeviceSession()
                 this.result = result()
                 if (className == "com.miui.headset.runtime.AncBatteryController" && methodName == "getHeadsetPropertyBlock") {
                     notifyHeadsetPropertyChanged(instance, device, 4)
@@ -487,6 +558,10 @@ object MiLinkServiceHook : HookContext() {
                 val device = args[0] as? BluetoothDevice ?: return@hookBefore
                 val route = routeForDevice(device)
                 if (!route.isSupported) return@hookBefore
+                if (!currentSessionConfirmed) {
+                    this.result = 0
+                    return@hookBefore
+                }
                 if (!isCurrentHuaweiDevice(device, route)) return@hookBefore
                 if (!route.supportsAnc || requiresTransparency && !route.supportsTransparency) {
                     this.result = 0
@@ -514,6 +589,10 @@ object MiLinkServiceHook : HookContext() {
                 val device = args[0] as? BluetoothDevice ?: return@hookBefore
                 val route = routeForDevice(device)
                 if (!route.isSupported) return@hookBefore
+                if (!currentSessionConfirmed) {
+                    this.result = 0
+                    return@hookBefore
+                }
                 if (!isCurrentHuaweiDevice(device, route)) return@hookBefore
                 if (!route.supportsAnc) {
                     this.result = 0
@@ -548,13 +627,19 @@ object MiLinkServiceHook : HookContext() {
         methodName: String,
         requiresAnc: Boolean = false,
         requiresCurrentState: Boolean = false,
+        noAncResult: (() -> Any)? = null,
         result: () -> Any,
     ) {
         runCatching {
             hookAfter(findMethodByParamCount("com.miui.headset.api.HeadsetInfo", methodName, 0)) {
                 val route = routeForHeadsetInfo(instance)
                 if (!route.isSupported || requiresAnc && !route.supportsAnc) return@hookAfter
+                if (!route.supportsAnc && noAncResult != null) {
+                    this.result = noAncResult()
+                    return@hookAfter
+                }
                 if (requiresCurrentState && !isCurrentHeadsetInfo(instance, route)) return@hookAfter
+                if (requiresCurrentState && !currentSessionConfirmed) requestCurrentDeviceSession()
                 this.result = result()
             }
         }.onFailure { Log.w(TAG, "hook HeadsetInfo.$methodName skipped", it) }
@@ -665,6 +750,10 @@ object MiLinkServiceHook : HookContext() {
                 if (currentHuaweiRoute() != HuaweiDeviceRoute.HUAWEI_FREECLIP2 ||
                     !isTargetCirculateHeadset(serviceInfo)
                 ) {
+                    return@hookBefore
+                }
+                if (!currentSessionConfirmed) {
+                    result = CompletableFuture.completedFuture(208)
                     return@hookBefore
                 }
                 val mode = freeClip2SpatialModeForMiLinkAudioEffect(args[1] as? Int ?: -1)
@@ -1382,6 +1471,7 @@ object MiLinkServiceHook : HookContext() {
         }
         val selected = selectionForStatus(route, currentAnc)?.subMode ?: options.first().value
         val targetSelector = selector ?: HuaweiAncSubModeSelectorView(ancContainer.context) { subMode ->
+            if (!currentSessionConfirmed) return@HuaweiAncSubModeSelectorView
             val activeRoute = currentHuaweiRoute()
             val selection = selectionForStatus(activeRoute, currentAnc, subMode)
                 ?: return@HuaweiAncSubModeSelectorView
@@ -2059,6 +2149,7 @@ object MiLinkServiceHook : HookContext() {
                     HuaweiPodsAction.ACTION_PODS_DISCONNECTED -> {
                         if (!forgetCurrentDevice(receivedIntent)) return
                         saveState(context)
+                        requestCurrentDeviceSession(context)
                         refreshAncCards("disconnected")
                         refreshFreeClip2AudioEffectSections("disconnected")
                     }
@@ -2323,6 +2414,7 @@ object MiLinkServiceHook : HookContext() {
     }
 
     private fun sendHuaweiAnc(selection: MiLinkAncSelection, fallbackContext: Context? = null) {
+        if (!currentSessionConfirmed) return
         val route = currentHuaweiRoute()
         if (!route.supportsAnc || selection.status == 3 && !route.supportsTransparency) {
             Log.d(TAG, "sendHuaweiAnc skipped: route=$route selection=$selection")
@@ -2401,6 +2493,7 @@ object MiLinkServiceHook : HookContext() {
     }
 
     private fun requestFreeClip2AudioState(reason: String, force: Boolean = false) {
+        if (!currentSessionConfirmed) return
         val route = currentHuaweiRoute()
         val address = currentAddress?.takeIf(String::isNotBlank) ?: return
         val ctx = context ?: return
@@ -2423,11 +2516,31 @@ object MiLinkServiceHook : HookContext() {
         Log.d(TAG, "MiLink FreeClip2 audio readback requested reason=$reason address=$address")
     }
 
+    private fun requestCurrentDeviceSession(fallbackContext: Context? = null) {
+        if (currentSessionConfirmed) return
+        val ctx = fallbackContext ?: context ?: return
+        val device = currentBluetoothDevice(ctx) ?: return
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastDeviceSessionRequestAt < DEVICE_SESSION_REQUEST_MIN_INTERVAL_MS) return
+        lastDeviceSessionRequestAt = now
+        runCatching {
+            ctx.sendBroadcast(Intent(HuaweiPodsAction.ACTION_CONNECT_POD_REQUEST).apply {
+                putExtra("device", device)
+                setPackage("com.android.bluetooth")
+                addFlags(Intent.FLAG_RECEIVER_FOREGROUND)
+            })
+        }.onFailure {
+            lastDeviceSessionRequestAt = 0L
+            Log.w(TAG, "MiLink device session request failed address=${device.address}", it)
+        }
+    }
+
     private fun sendFreeClip2AudioSetting(
         kind: String,
         value: String,
         fallbackContext: Context? = null,
     ): Boolean {
+        if (!currentSessionConfirmed) return false
         val route = currentHuaweiRoute()
         if (route != HuaweiDeviceRoute.HUAWEI_FREECLIP2) {
             Log.w(TAG, "FreeClip2 audio setting ignored for route=$route kind=$kind value=$value")
@@ -2527,11 +2640,15 @@ object MiLinkServiceHook : HookContext() {
             return false
         }
 
-        currentAddress = null
-        currentName = null
-        currentRoute = HuaweiDeviceRoute.UNSUPPORTED
+        val keepDisplayState = isCurrentDeviceStillConnected()
+        if (!keepDisplayState) {
+            currentAddress = null
+            currentName = null
+            currentRoute = HuaweiDeviceRoute.UNSUPPORTED
+            currentBattery = BatteryParams()
+        }
+        // 双设备切换时只终止旧会话，设备中心会通过仍连接的传输重新建立会话并继续刷新。
         currentSessionConfirmed = false
-        currentBattery = BatteryParams()
         currentAnc = NoiseControlMode.OFF.broadcastStatus
         currentAncSubMode = null
         currentTransparencySubMode = null
@@ -2540,6 +2657,31 @@ object MiLinkServiceHook : HookContext() {
         circulationUiCompletedUntilMs = 0L
         circulationTargetHostId = null
         return true
+    }
+
+    private fun isCurrentDeviceStillConnected(): Boolean {
+        val device = currentBluetoothDevice() ?: return false
+        return runCatching {
+            val method = device.javaClass.methods.firstOrNull {
+                it.name == "isConnected" && it.parameterCount in 0..1
+            } ?: return@runCatching false
+            when (method.parameterCount) {
+                0 -> method.invoke(device) as? Boolean == true
+                else -> method.invoke(device, BluetoothDevice.TRANSPORT_AUTO) as? Boolean == true
+            }
+        }.getOrDefault(false)
+    }
+
+    private fun currentBluetoothDevice(fallbackContext: Context? = null): BluetoothDevice? {
+        val address = currentAddress
+            ?.trim()
+            ?.uppercase()
+            ?.takeIf(bluetoothAddressPattern::matches)
+            ?: return null
+        val ctx = fallbackContext ?: context ?: return null
+        return runCatching {
+            ctx.getSystemService(BluetoothManager::class.java)?.adapter?.getRemoteDevice(address)
+        }.getOrNull()
     }
 
     private fun resetAncState(route: HuaweiDeviceRoute) {

--- a/app/src/test/java/moe/chenxy/huaweipods/hook/milink/MiLinkAncRoutingTest.kt
+++ b/app/src/test/java/moe/chenxy/huaweipods/hook/milink/MiLinkAncRoutingTest.kt
@@ -45,7 +45,8 @@ class MiLinkAncRoutingTest {
             HuaweiDeviceRoute.HUAWEI_EYEWEAR2,
         ).forEach { route ->
             assertNull(miLinkAncModeFor(route, 2))
-            assertEquals(0, miLinkHostAncStateFor(route, 2))
+            assertEquals(-1, miLinkHostAncStateFor(route, 2))
+            assertEquals(0, miLinkAncSwitchStateFor(route))
             assertNull(huaweiAncStatusForMiLink(route, 0))
             assertNull(huaweiAncStatusForMiLink(route, 1))
             assertNull(huaweiAncStatusForMiLink(route, 2))
@@ -63,6 +64,7 @@ class MiLinkAncRoutingTest {
             assertEquals(0, miLinkAncModeFor(route, 1))
             assertEquals(1, miLinkAncModeFor(route, 2))
             assertEquals(2, miLinkAncModeFor(route, 3))
+            assertEquals(1, miLinkAncSwitchStateFor(route))
             assertEquals(1, huaweiAncStatusForMiLink(route, 0))
             assertEquals(2, huaweiAncStatusForMiLink(route, 1))
             assertEquals(3, huaweiAncStatusForMiLink(route, 2))
@@ -78,6 +80,7 @@ class MiLinkAncRoutingTest {
         ).forEach { route ->
             assertEquals(0, miLinkAncModeFor(route, 1))
             assertEquals(1, miLinkAncModeFor(route, 2))
+            assertEquals(1, miLinkAncSwitchStateFor(route))
             assertNull(huaweiAncStatusForMiLink(route, 2))
         }
     }


### PR DESCRIPTION
## 修改内容

- 修复无 ANC 设备的融合设备中心弹窗仍预留 ANC 区块高度的问题
- 修复关闭“通知栏显示”后，耳机通知仍然出现的问题
- 修复双设备连接时耳机被另一台设备占用后，设备中心丢失电量、图标和状态的问题

## 实现说明

### 融合设备中心

- 为不支持 ANC 的华为设备返回正确的 ANC 能力、不可用状态和开关状态，避免宿主将其识别为“支持 ANC 但当前关闭”
- 在双设备切换导致当前控制会话结束时，如果耳机仍保持蓝牙连接，则保留设备中心的显示状态
- 主动请求重新建立当前设备会话，使电量等信息可以继续更新
- 在会话尚未确认时阻止 ANC 和音效写操作，避免命令发送到错误设备

### 通知栏开关

- 将 HyperOS 的通知栏设置和查询命令（114/115）交给蓝牙服务处理
- 使用系统原有的 `DeviceIdCached/detail_notification<address>` 状态保存通知开关
- 关闭开关时立即移除现有通知，并在创建通知前后重新检查状态，避免电量更新重新创建通知
- 开启开关时请求恢复当前耳机通知

## 验证

测试环境：

- HUAWEI FreeClip 2
- Xiaomi 17
- HyperOS 3.0.313

已真机验证：

- 无 ANC 设备弹窗高度正常
- 关闭“通知栏显示”后通知会消失，后续状态更新不会重新显示
- 双设备连接时，被另一台设备占用后仍能显示并更新耳机图标、电量等信息
- 耳机重新回到当前设备后，控制会话能够恢复

同时更新了 `MiLinkAncRoutingTest`，覆盖无 ANC 状态和开关能力映射。

Fixes #5